### PR TITLE
fix(security): pin GitHub Actions to commit SHAs in CI/publish workflows

### DIFF
--- a/.github/workflows/pypi-nightly.yaml
+++ b/.github/workflows/pypi-nightly.yaml
@@ -13,9 +13,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@0f07f7f756721ebd886c2462646a35f78a8bc4de # v1
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -11,9 +11,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@0f07f7f756721ebd886c2462646a35f78a8bc4de # v1
       with:
         python-version: '3.x'
     - name: Install dependencies


### PR DESCRIPTION
## Summary

This workflow uses **mutable tag references** for GitHub Actions. Tag-pinned actions can be silently redirected to malicious code (compromised maintainer, tag deletion + recreation, repo takeover). Any action running in a job that holds `PYPI_TOKEN` / `PYPI_API_TOKEN` can exfiltrate that token and publish a backdoored release, poisoning every downstream user.

## Fix

All action references pinned to their immutable commit SHA (tag preserved as comment). Follows the [GitHub security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).